### PR TITLE
Only printout after certain defined threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ If we would like to:
 without touching the testartifact then we could set up the `actions.txt` (the config of the trace agent) like this:
 
 ```
-elapsed_time_in_nano net.test.TestClass test
-elapsed_time_in_ms net.test.TestClass2nd anotherMethod
-stack_trace net.test.TestClass2nd anotherMethod
-trace_args net.test.TestClass2nd methodWithArgs
-trace_retval net.test.TestClass2nd methodWithArgs
+elapsed_time_in_nano net.test.TestClass test params
+elapsed_time_in_ms net.test.TestClass2nd anotherMethod params
+stack_trace net.test.TestClass2nd anotherMethod params
+trace_args net.test.TestClass2nd methodWithArgs params
+trace_retval net.test.TestClass2nd methodWithArgs params
+counter net.test.TestClass2nd methodToCounter params
 ```
 
 This `actions.txt` is part of the trace agent jar as a resource (no recompile/rebuild is needed just edit the file within the jar).
@@ -106,7 +107,7 @@ TraceAgent (trace_retval): `public int net.test.TestClass2nd.methodWithArgs(java
 The config format is simple lines with the following structure:
 
 ```
-<action-name> <class-name> <method-name>
+<action-name> <class-name> <method-name> <params:Optional>
 ```
 
 Empty lines and lines starting with `#` (comments) are skipped. 
@@ -143,6 +144,37 @@ Disclaimer: currently parsing is done via simply splitting the strings so commas
 (if there is a need then escaping should be introduced in the future).
 
 Not all the parameters can be used at both places. And there will be parameters which make sense only for one specific action only (or for a set of actions).
+
+### Parameters
+
+* `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
+* `dateTimeFormat` (scope: `global`) Can be used to specify formatting for datetimes. The default is [ISO_LOCAL_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME). 
+  For the details and valid patterns please check: [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+* `count_frequency` (scope: `action` only) Specifies after how many calls there will be a printout. 
+* `log_threshold_ms` (scope: `action` only) This threshold represents the elapsed number of milliseconds after there will be a printout. The default is `0`, which means it should printout on every call. For example, if we only like to log an action when it takes more than 1 second to complete: `elapsed_time_in_ms net.test.TestClass test log_threshold_ms:1000`
+
+### Actions and supported parameters
+
+All actions have the following set of arguments 
+
+* `class-name`: **Required** name for the class to be traced
+
+* `action-name`: **Required** name of method to be traced
+
+* `params`: Optional list of parameters in form of `<key_1>:<value_1>,<key_2>:<value_2>,...<key_N>`<br>
+
+Here is the full list of actions and supported `params` 
+
+| Action               | Supported arguments               |
+| -------------------- | --------------------------------- |
+| elapsed_time_in_nano | isDateLogged,  log_threshold_nano |
+| elapsed_time_in_ms   | isDateLogged, log_threshold_ms    |
+| stack_trace          | isDateLogged, log_threshold_ms    |
+| trace_args           | isDateLogged, log_threshold_ms    |
+| trace_retval         | isDateLogged, log_threshold_ms    |
+| counter              | isDateLogged, count_frequency     |
+
+
 
 ### Example for common argument (both global and action argument): `isDateLogged`
 
@@ -355,3 +387,16 @@ TraceAgent (counter): 20
 TraceAgent (counter): 24
 TraceAgent (counter): 28
 ```
+
+# Replacing actions directly into the jar
+
+```bash
+# Create or use already created actions.txt file
+echo "elapsed_time_in_ms org.apache.spark.executor.CoarseGrainedExecutorBackend onConnected" > actions.txt
+
+# Replace the actions file in the jar
+jar uf trace-agent-1.0-SNAPSHOT.jar actions.txt
+
+# done
+```
+

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ If we would like to:
 without touching the testartifact then we could set up the `actions.txt` (the config of the trace agent) like this:
 
 ```
-elapsed_time_in_nano net.test.TestClass test params
-elapsed_time_in_ms net.test.TestClass2nd anotherMethod params
-stack_trace net.test.TestClass2nd anotherMethod params
-trace_args net.test.TestClass2nd methodWithArgs params
-trace_retval net.test.TestClass2nd methodWithArgs params
-counter net.test.TestClass2nd methodToCounter params
+elapsed_time_in_nano net.test.TestClass test
+elapsed_time_in_ms net.test.TestClass2nd anotherMethod
+stack_trace net.test.TestClass2nd anotherMethod
+trace_args net.test.TestClass2nd methodWithArgs
+trace_retval net.test.TestClass2nd methodWithArgs
+counter net.test.TestClass2nd methodToCounter
 ```
 
 This `actions.txt` is part of the trace agent jar as a resource (no recompile/rebuild is needed just edit the file within the jar).
@@ -107,7 +107,7 @@ TraceAgent (trace_retval): `public int net.test.TestClass2nd.methodWithArgs(java
 The config format is simple lines with the following structure:
 
 ```
-<action-name> <class-name> <method-name> <params:Optional>
+<action-name> <class-name> <method-name> <optionalParameters>
 ```
 
 Empty lines and lines starting with `#` (comments) are skipped. 
@@ -144,37 +144,6 @@ Disclaimer: currently parsing is done via simply splitting the strings so commas
 (if there is a need then escaping should be introduced in the future).
 
 Not all the parameters can be used at both places. And there will be parameters which make sense only for one specific action only (or for a set of actions).
-
-### Parameters
-
-* `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
-* `dateTimeFormat` (scope: `global`) Can be used to specify formatting for datetimes. The default is [ISO_LOCAL_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME). 
-  For the details and valid patterns please check: [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
-* `count_frequency` (scope: `action` only) Specifies after how many calls there will be a printout. 
-* `log_threshold_ms` (scope: `action` only) This threshold represents the elapsed number of milliseconds after there will be a printout. The default is `0`, which means it should printout on every call. For example, if we only like to log an action when it takes more than 1 second to complete: `elapsed_time_in_ms net.test.TestClass test log_threshold_ms:1000`
-
-### Actions and supported parameters
-
-All actions have the following set of arguments 
-
-* `class-name`: **Required** name for the class to be traced
-
-* `action-name`: **Required** name of method to be traced
-
-* `params`: Optional list of parameters in form of `<key_1>:<value_1>,<key_2>:<value_2>,...<key_N>`<br>
-
-Here is the full list of actions and supported `params` 
-
-| Action               | Supported arguments               |
-| -------------------- | --------------------------------- |
-| elapsed_time_in_nano | isDateLogged,  log_threshold_nano |
-| elapsed_time_in_ms   | isDateLogged, log_threshold_ms    |
-| stack_trace          | isDateLogged, log_threshold_ms    |
-| trace_args           | isDateLogged, log_threshold_ms    |
-| trace_retval         | isDateLogged, log_threshold_ms    |
-| counter              | isDateLogged, count_frequency     |
-
-
 
 ### Example for common argument (both global and action argument): `isDateLogged`
 
@@ -262,6 +231,35 @@ In this case all the rules are used from both the internal and external action f
 In distributed environment when external action file is used you should take care on each node the action file is really can be accessed using the path.
 Otherwise the error is logged but the application continues: "TraceAgent does not find the external action file: <file>".
 
+### Parameters
+
+* `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
+* `dateTimeFormat` (scope: `global`) Can be used to specify formatting for datetimes. The default is [ISO_LOCAL_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME). 
+  For the details and valid patterns please check: [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+* `count_frequency` (scope: `action` only) Specifies after how many calls there will be a printout. 
+* `log_threshold_ms` (scope: `action` only) This threshold represents the elapsed number of milliseconds after there will be a printout. The default is `0`, which means it should printout on every call. For example, if we only like to log an action when it takes more than 1 second to complete: `elapsed_time_in_ms net.test.TestClass test log_threshold_ms:1000`
+* `log_threshold_nano` (scope: `action` only) Similar to `log_threshold_ms` but in nanoseconds. 
+
+### Actions and supported parameters
+
+All actions have the following set of arguments 
+
+* `class-name`: **Required** name for the class to be traced
+
+* `action-name`: **Required** name of method to be traced
+
+* `params`: Optional list of parameters in form of `<key_1>:<value_1>,<key_2>:<value_2>,...<key_N>`<br>
+
+Here is the full list of actions and supported `params` 
+
+| Action               | Supported arguments              |
+| -------------------- | -------------------------------- |
+| elapsed_time_in_nano | isDateLogged, log_threshold_nano |
+| elapsed_time_in_ms   | isDateLogged, log_threshold_ms   |
+| stack_trace          | isDateLogged, log_threshold_ms   |
+| trace_args           | isDateLogged, log_threshold_ms   |
+| trace_retval         | isDateLogged, log_threshold_ms   |
+| counter              | isDateLogged, count_frequency    |
 
 ## Some complex examples how to specify a javaagent
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ elapsed_time_in_ms net.test.TestClass2nd anotherMethod
 stack_trace net.test.TestClass2nd anotherMethod
 trace_args net.test.TestClass2nd methodWithArgs
 trace_retval net.test.TestClass2nd methodWithArgs
-counter net.test.TestClass2nd methodToCounter
+counter net.test.TestClass2nd methodWithArgs
 ```
 
 This `actions.txt` is part of the trace agent jar as a resource (no recompile/rebuild is needed just edit the file within the jar).
@@ -145,40 +145,6 @@ Disclaimer: currently parsing is done via simply splitting the strings so commas
 
 Not all the parameters can be used at both places. And there will be parameters which make sense only for one specific action only (or for a set of actions).
 
-<<<<<<< HEAD
-=======
-### Parameters
-
-* `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
-* `dateTimeFormat` (scope: `global`) Can be used to specify formatting for datetimes. The default is [ISO_LOCAL_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME). 
-  For the details and valid patterns please check: [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
-* `count_frequency` (scope: `action` only) Specifies after how many calls there will be a printout. 
-* `log_threshold_ms` (scope: `action` only) This threshold represents the elapsed number of milliseconds after there will be a printout. The default is `0`, which means it should printout on every call. For example, if we only like to log an action when it takes more than 1 second to complete: `elapsed_time_in_ms net.test.TestClass test log_threshold_ms:1000`
-
-### Actions and supported parameters
-
-All actions have the following set of arguments 
-
-* `class-name`: **Required** name for the class to be traced
-
-* `action-name`: **Required** name of method to be traced
-
-* `params`: Optional list of parameters in form of `<key_1>:<value_1>,<key_2>:<value_2>,...<key_N>`<br>
-
-Here is the full list of actions and supported `params` 
-
-| Action               | Supported arguments               |
-| -------------------- | --------------------------------- |
-| elapsed_time_in_nano | isDateLogged, log_threshold_nano |
-| elapsed_time_in_ms   | isDateLogged, log_threshold_ms    |
-| stack_trace          | isDateLogged, log_threshold_ms    |
-| trace_args           | isDateLogged, log_threshold_ms    |
-| trace_retval         | isDateLogged, log_threshold_ms    |
-| counter              | isDateLogged, count_frequency     |
-
-
-
->>>>>>> 061c4601f220f50a388df92749c120edb9e27be9
 ### Example for common argument (both global and action argument): `isDateLogged`
 
 The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
@@ -265,7 +231,7 @@ In this case all the rules are used from both the internal and external action f
 In distributed environment when external action file is used you should take care on each node the action file is really can be accessed using the path.
 Otherwise the error is logged but the application continues: "TraceAgent does not find the external action file: <file>".
 
-### Parameters
+### Summary of Parameters
 
 * `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.
 * `dateTimeFormat` (scope: `global`) Can be used to specify formatting for datetimes. The default is [ISO_LOCAL_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME). 

--- a/src/main/java/net/test/ArgUtils.java
+++ b/src/main/java/net/test/ArgUtils.java
@@ -1,16 +1,13 @@
 package net.test;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ArgUtils {
 
-  public static Map<String, String> parseOptionalArgs(List<String> knownKeys, String arguments) {
+  public static ArgumentsCollection parseOptionalArgs(List<String> knownKeys, String arguments) {
     List<String> usedKeys = new ArrayList<String>();
-    Map<String, String> parsedArgs = new HashMap<String, String>();
+    ArgumentsCollection parsedArgs = new ArgumentsCollection();
     if (arguments != null && !arguments.isEmpty()) {
       for (String keyValue: arguments.split(",")) {
         String[] kv = keyValue.split(":");

--- a/src/main/java/net/test/ArgumentsCollection.java
+++ b/src/main/java/net/test/ArgumentsCollection.java
@@ -1,0 +1,35 @@
+package net.test;
+
+import java.util.HashMap;
+
+public class ArgumentsCollection extends HashMap<String, String> {
+
+    public int parseInt(String key, int defaultValue) {
+        String valueStr = this.get(key);
+        int valueInt = defaultValue;
+        if (valueStr != null) {
+            try {
+                valueInt = Integer.valueOf(valueStr);
+            } catch (NumberFormatException nfe) {
+                System.err.println("TraceAgent (counter) invalid `" + key + "` param value: `" + valueStr + "` using the default: " + defaultValue);
+
+            }
+        }
+        return valueInt;
+    }
+
+    public long parseLong(String key, long defaultValue) {
+        String valueStr = this.get(key);
+        long valueLong = defaultValue;
+        if (valueStr != null) {
+            try {
+                valueLong = Long.valueOf(valueStr);
+            } catch (NumberFormatException nfe) {
+                System.err.println("TraceAgent (counter) invalid `" + key + "` param value: `" + valueStr + "` using the default: " + defaultValue);
+
+            }
+        }
+        return valueLong;
+    }
+
+}

--- a/src/main/java/net/test/interceptor/CounterInterceptor.java
+++ b/src/main/java/net/test/interceptor/CounterInterceptor.java
@@ -1,6 +1,7 @@
 package net.test.interceptor;
 
 import net.test.ArgUtils;
+import net.test.ArgumentsCollection;
 import net.test.CommonActionArgs;
 import net.test.DefaultArguments;
 
@@ -30,18 +31,9 @@ public class CounterInterceptor {
   private long counter = 0;
 
   public CounterInterceptor(String actionArgs, DefaultArguments defaults) {
-    Map<String, String> parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
+    ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
     this.commonActionArgs = new CommonActionArgs(parsed, defaults);
-    String countFrequencyStr = parsed.get(COUNT_FREQUENCY);
-    int countFrequencyInt = 100;
-    if (countFrequencyStr != null) {
-      try {
-        countFrequencyInt = Integer.valueOf(countFrequencyStr);
-      } catch (NumberFormatException nfe) {
-        System.err.println("TraceAgent (counter) invalid `" + COUNT_FREQUENCY + "` param value: `" + countFrequencyStr + "` using the default: " + countFrequencyInt);
-      }
-    }
-    this.countFrequency = countFrequencyInt;
+    this.countFrequency = parsed.parseInt(COUNT_FREQUENCY, 100);
   }
 
 

--- a/src/main/java/net/test/interceptor/StackTraceInterceptor.java
+++ b/src/main/java/net/test/interceptor/StackTraceInterceptor.java
@@ -49,11 +49,11 @@ public class StackTraceInterceptor {
 
   @RuntimeType
   public Object intercept(@Origin Method method, @SuperCall Callable<?> callable) throws Exception  {
-    long start = System.currentTimeMillis();
+    long start = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
     try {
       return callable.call();
     } finally {
-      long end = System.currentTimeMillis();
+      long end = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
       if(this.logThresholdMs == 0 || end - start >= this.logThresholdMs) {
         Exception e = new MyException(commonActionArgs.addPrefix("TraceAgent (stack trace)"));
         StackTraceElement[] stElements = Thread.currentThread().getStackTrace();

--- a/src/main/java/net/test/interceptor/TraceArgsInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceArgsInterceptor.java
@@ -37,11 +37,11 @@ public class TraceArgsInterceptor {
 
   @RuntimeType
   public Object intercept(@Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable) throws Exception  {
-    long start = System.currentTimeMillis();
+    long start = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
     try {
       return callable.call();
     } finally {
-      long end = System.currentTimeMillis();
+      long end = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
       if(this.logThresholdMs == 0 || end - start >= this.logThresholdMs) {
         System.out.println(
                 commonActionArgs.addPrefix("TraceAgent (trace_args): `" + method + " called with " + Arrays.toString(allArguments)));

--- a/src/main/java/net/test/interceptor/TraceArgsInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceArgsInterceptor.java
@@ -1,6 +1,7 @@
 package net.test.interceptor;
 
 import net.test.ArgUtils;
+import net.test.ArgumentsCollection;
 import net.test.CommonActionArgs;
 import net.test.DefaultArguments;
 
@@ -18,21 +19,33 @@ import java.util.concurrent.Callable;
 
 public class TraceArgsInterceptor {
 
+  private static String LOG_THRESHOLD_MILLISECONDS = "log_threshold_ms";
+
   private static List<String> KNOWN_ARGS = 
-    Arrays.asList(CommonActionArgs.IS_DATE_LOGGED);
+    Arrays.asList(CommonActionArgs.IS_DATE_LOGGED, LOG_THRESHOLD_MILLISECONDS);
 
   private CommonActionArgs commonActionArgs;
 
+  private final long logThresholdMs;
+
   public TraceArgsInterceptor(String actionArgs, DefaultArguments defaults) {
-    Map<String, String> parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
+    ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
     this.commonActionArgs = new CommonActionArgs(parsed, defaults);
+    this.logThresholdMs = parsed.parseLong(LOG_THRESHOLD_MILLISECONDS, 0);
   }
 
 
   @RuntimeType
   public Object intercept(@Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable) throws Exception  {
-    System.out.println(
-      commonActionArgs.addPrefix("TraceAgent (trace_args): `" + method + " called with " + Arrays.toString(allArguments)));
-    return callable.call();
+    long start = System.currentTimeMillis();
+    try {
+      return callable.call();
+    } finally {
+      long end = System.currentTimeMillis();
+      if(this.logThresholdMs == 0 || end - start >= this.logThresholdMs) {
+        System.out.println(
+                commonActionArgs.addPrefix("TraceAgent (trace_args): `" + method + " called with " + Arrays.toString(allArguments)));
+      }
+    }
   }
 }

--- a/src/main/java/net/test/interceptor/TraceRetValueInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceRetValueInterceptor.java
@@ -1,6 +1,7 @@
 package net.test.interceptor;
 
 import net.test.ArgUtils;
+import net.test.ArgumentsCollection;
 import net.test.CommonActionArgs;
 import net.test.DefaultArguments;
 
@@ -18,22 +19,31 @@ import java.util.concurrent.Callable;
 
 public class TraceRetValueInterceptor {
 
+  private static String LOG_THRESHOLD_MILLISECONDS = "log_threshold_ms";
+
   private static List<String> KNOWN_ARGS = 
-    Arrays.asList(CommonActionArgs.IS_DATE_LOGGED);
+    Arrays.asList(CommonActionArgs.IS_DATE_LOGGED, LOG_THRESHOLD_MILLISECONDS);
 
   private CommonActionArgs commonActionArgs;
 
+  private final long logThresholdMs;
+
   public TraceRetValueInterceptor(String actionArgs, DefaultArguments defaults) {
-    Map<String, String> parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
+    ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
     this.commonActionArgs = new CommonActionArgs(parsed, defaults);
+    this.logThresholdMs = parsed.parseLong(LOG_THRESHOLD_MILLISECONDS, 0);
   }
 
 
   @RuntimeType
   public Object intercept(@Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable) throws Exception  {
+    long start = System.currentTimeMillis();
     Object retVal = callable.call();
-    System.out.println(
-      commonActionArgs.addPrefix("TraceAgent (trace_retval): `" + method + " returns with " + retVal));
+    long end = System.currentTimeMillis();
+    if(this.logThresholdMs == 0 || end - start >= this.logThresholdMs) {
+      System.out.println(
+              commonActionArgs.addPrefix("TraceAgent (trace_retval): `" + method + " returns with " + retVal));
+    }
     return retVal;
   }
 }

--- a/src/main/java/net/test/interceptor/TraceRetValueInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceRetValueInterceptor.java
@@ -37,9 +37,9 @@ public class TraceRetValueInterceptor {
 
   @RuntimeType
   public Object intercept(@Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable) throws Exception  {
-    long start = System.currentTimeMillis();
+    long start = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
     Object retVal = callable.call();
-    long end = System.currentTimeMillis();
+    long end = (this.logThresholdMs == 0) ? 0 : System.currentTimeMillis();
     if(this.logThresholdMs == 0 || end - start >= this.logThresholdMs) {
       System.out.println(
               commonActionArgs.addPrefix("TraceAgent (trace_retval): `" + method + " returns with " + retVal));


### PR DESCRIPTION
This will help avoid generating high volume logging. I've added 2 parameters:

* log_threshold_ms (scope: `action` only) This threshold represents the elapsed number of milliseconds after there will be a printout. The default is `0`, which means it should printout on every call. For example, if we only like to log an action when it takes more than 1 second to complete: `elapsed_time_in_ms net.test.TestClass test log_threshold_ms:1000`
* log_threshold_nano (scope: `action` only) Similar to `log_threshold_ms` but in nanoseconds. 

Above 2 parameters apply to most of the actions. 

I'm also documenting few changes into the README.md. Please review. Thanks!