### PR TITLE
Add init logs

### DIFF
--- a/src/main/java/net/test/TraceAction.java
+++ b/src/main/java/net/test/TraceAction.java
@@ -33,20 +33,12 @@ class TraceAction {
 
   @Override
   public String toString() {
-    return "TraceAction{"
-        + "actionId='"
-        + actionId
-        + '\''
-        + ", classMatcherExp='"
-        + classMatcherExp
-        + '\''
-        + ", methodMatcherExp='"
-        + methodMatcherExp
-        + '\''
-        + ", actionArgs='"
-        + actionArgs
-        + '\''
-        + '}';
+    return "TraceAction{" +
+        "actionId='" + actionId + '\'' +
+        ", classMatcherExp='" + classMatcherExp + '\'' +
+        ", methodMatcherExp='" + methodMatcherExp + '\'' +
+        ", actionArgs='" + actionArgs + '\'' +
+        '}';
   }
 
   public Object getActionInterceptor(DefaultArguments defaultArguments) {

--- a/src/main/java/net/test/TraceAction.java
+++ b/src/main/java/net/test/TraceAction.java
@@ -31,6 +31,24 @@ class TraceAction {
     this(actionId, classMatcherExp, methodMatcherExp, null);
   }
 
+  @Override
+  public String toString() {
+    return "TraceAction{"
+        + "actionId='"
+        + actionId
+        + '\''
+        + ", classMatcherExp='"
+        + classMatcherExp
+        + '\''
+        + ", methodMatcherExp='"
+        + methodMatcherExp
+        + '\''
+        + ", actionArgs='"
+        + actionArgs
+        + '\''
+        + '}';
+  }
+
   public Object getActionInterceptor(DefaultArguments defaultArguments) {
     final Object interceptor;
     if (actionId.equals("elapsed_time_in_nano")) {

--- a/src/main/java/net/test/TraceAgent.java
+++ b/src/main/java/net/test/TraceAgent.java
@@ -74,6 +74,7 @@ public class TraceAgent {
   }
 
   private void installActions(List<TraceAction> actions) {
+    System.out.println("TraceAgent tries to install actions: " + actions);
     for (TraceAction action : actions) {
       final Object interceptor = action.getActionInterceptor(traceAgentArgs);
       if (interceptor != null) {
@@ -87,6 +88,7 @@ public class TraceAgent {
             .installOn(instrumentation);
       }
     }
+    System.out.println("TraceAgent installed actions successfully");
   }
 
   private void install() {
@@ -110,6 +112,7 @@ public class TraceAgent {
   }
 
   public static void premain(String arguments, Instrumentation instrumentation) {
+    System.out.println("TraceAgent is initializing");
     TraceAgentArgs traceAgentArgs = new TraceAgentArgs(arguments);
     TraceAgent traceAgent = new TraceAgent(traceAgentArgs, instrumentation);
     traceAgent.install();


### PR DESCRIPTION
It would be good to add some init logs to see something is loaded or at least tried to be loaded. The log looks like this:
```
TraceAgent is initializing
TraceAgent tries to install actions: [TraceAction{actionId='trace_args', classMatcherExp='org.apache.hadoop.security.ProviderUtils', methodMatcherExp='locatePassword', actionArgs='null'}, TraceAction{actionId='trace_retval', classMatcherExp='org.apache.hadoop.security.ProviderUtils', methodMatcherExp='locatePassword', actionArgs='true'}]
TraceAgent detected a wrong argument format: true
TraceAgent installed actions successfully
```
