### PR TITLE
Added trace_login_config config to trace JVM security config

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Here is the full list of actions and supported `params`
 | trace_retval         | isDateLogged, log_threshold_ms                |
 | counter              | isDateLogged, count_frequency                 |
 | avg_timing           | isDateLogged, window_length                   |
+| trace_login_config   | isDateLogged, entry_name                      |
 
 
 ## Some complex examples how to specify a javaagent

--- a/README.md
+++ b/README.md
@@ -273,6 +273,31 @@ TraceAgent (avg_timing): `public void net.test.TestClass2nd.calledSeveralTimes()
 
 **Important: if it is used with REGEXP then it traces at the method where `window_lenth` reached but it contains the elapsed times of all the matching methods!**
 
+# trace_login_config action
+
+The action traces the JVM `javax.security.auth.login.Configuration` entry which is set as parameter.
+If the entry is not found then the output will be `Not Found`.
+
+Example:
+
+```
+trace_login_config A foo entry_name:KafkaClient
+```
+
+Example output:
+
+```
+TraceAgent (trace_login_config): `public void A.foo() login config for entry "KafkaClient"
+KafkaClient {
+	com.sun.security.auth.module.Krb5LoginModule LoginModuleControlFlag: required
+	principal=user@MY.DOMAIN.COM
+	storeKey=true
+	keyTab=./kafka_client.keytab
+	useKeyTab=true
+	useTicketCache=false
+	serviceName=kafka
+```
+
 ### Summary of Parameters
 
 * `isDateLogged` (scope: both `global` and `action`) The `isDateLogged` can be used to request the current date time to be contained as prefix in the actions logs.

--- a/src/main/java/net/test/TraceAction.java
+++ b/src/main/java/net/test/TraceAction.java
@@ -61,6 +61,8 @@ class TraceAction {
       interceptor = new CounterInterceptor(actionArgs, defaultArguments);
     } else if (actionId.equals(AvgTimingInterceptorMs.NAME)) {
       interceptor = new AvgTimingInterceptorMs(actionArgs, defaultArguments);
+    } else if (actionId.equals(TraceLoginConfigInterceptor.NAME)) {
+      interceptor = new TraceLoginConfigInterceptor(actionArgs, defaultArguments);
     } else {
       System.err.println("TraceAgent detected an invalid action: " + actionId);
       interceptor = null;

--- a/src/main/java/net/test/interceptor/TraceLoginConfigInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceLoginConfigInterceptor.java
@@ -1,0 +1,68 @@
+package net.test.interceptor;
+
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.test.ArgUtils;
+import net.test.ArgumentsCollection;
+import net.test.CommonActionArgs;
+import net.test.DefaultArguments;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class TraceLoginConfigInterceptor {
+
+  public static String NAME = "trace_login_config";
+
+  private static String ENTRY_NAME = "entry_name";
+
+  private static List<String> KNOWN_ARGS =
+      Arrays.asList(CommonActionArgs.IS_DATE_LOGGED, ENTRY_NAME);
+
+  private CommonActionArgs commonActionArgs;
+
+  private final String entryName;
+
+  public TraceLoginConfigInterceptor(String actionArgs, DefaultArguments defaults) {
+    ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
+    this.commonActionArgs = new CommonActionArgs(parsed, defaults);
+    this.entryName = parsed.get(ENTRY_NAME);
+  }
+
+  @RuntimeType
+  public Object intercept(
+      @Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable)
+      throws Exception {
+    Configuration config = Configuration.getConfiguration();
+    AppConfigurationEntry[] appConfigurationEntries = config.getAppConfigurationEntry(entryName);
+    String entries = "";
+    if (appConfigurationEntries != null) {
+      for (AppConfigurationEntry e : appConfigurationEntries) {
+        entries += entryName + " {\n\t" + e.getLoginModuleName() + " " + e.getControlFlag() + "\n";
+        for (Map.Entry<String, ?> o : e.getOptions().entrySet()) {
+          entries += "\t" + o.getKey() + "=" + o.getValue() + "\n";
+        }
+        entries += "}\n";
+      }
+    }
+    if (entries.isEmpty()) {
+      entries = "Not Found";
+    }
+    System.out.println(
+        commonActionArgs.addPrefix(
+            "TraceAgent (trace_login_config): `"
+                + method
+                + " login config for entry \""
+                + entryName
+                + "\"\n"
+                + entries));
+    return callable.call();
+  }
+}


### PR DESCRIPTION
I've tested it the following way:
```
[gaborsomogyi:~/test] $ cat test.java 
class A {
  public void foo() {
    System.out.println("foo");
  }
}

class Test {
  public static void main(String[] args) {
    System.out.println("main");
    new A().foo();
  }
}
...
[gaborsomogyi:~/test] $ cat kafka_client_jaas.conf 
KafkaClient {
    com.sun.security.auth.module.Krb5LoginModule required
    useKeyTab=true
    storeKey=true
    keyTab="./kafka_client.keytab"
    useTicketCache=false
    serviceName="kafka"
    principal="user@MY.DOMAIN.COM";
};
...
[gaborsomogyi:~/trace-agent] trace_login_config* 3s ± cat src/main/resources/actions.txt 
trace_login_config A foo entry_name:KafkaClient
mvn clean package
```
And the result looks like this:
```
[gaborsomogyi:~/test] $ java -javaagent:/Users/gaborsomogyi/trace-agent/target/trace-agent-1.0-SNAPSHOT.jar -Djava.security.auth.login.config=./kafka_client_jaas.conf Test 
TraceAgent is initializing
TraceAgent tries to install actions: [{actionId='trace_login_config', classMatcher='A', methodMatcher='foo', actionArgs='entry_name:KafkaClient'}]
TraceAgent installed actions successfully
main
TraceAgent (trace_login_config): `public void A.foo() login config for entry "KafkaClient"
KafkaClient {
	com.sun.security.auth.module.Krb5LoginModule LoginModuleControlFlag: required
	principal=user@MY.DOMAIN.COM
	storeKey=true
	keyTab=./kafka_client.keytab
	useKeyTab=true
	useTicketCache=false
	serviceName=kafka
}

foo
```

