### PR TITLE
Added trace_args_with_method_call action

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,28 @@ KafkaClient {
 	useKeyTab=true
 	useTicketCache=false
 	serviceName=kafka
+};
+```
+
+# trace_param_call_retval action
+
+The action expects 2 parameters and calls a method on an argument instance:
+* `param_index` This is the index of the argument instance.
+* `method_to_call` This the the method which is called on the argument instance. Please note,
+only public member methods without any parameters can be used. The internal implementation uses
+reflection so it can be used in situations where the number of calls is low.
+
+Example:
+
+```
+trace_param_call_retval org.apache.hadoop.fs.FileSystem addDelegationTokens param_index:1,method_to_call:getAllTokens
+```
+
+Example output:
+
+```
+TraceAgent (trace_param_call_retval): public default org.apache.hadoop.security.token.Token[] org.apache.hadoop.security.token.DelegationTokenIssuer.addDelegationTokens(java.lang.String,org.apache.hadoop.security.Credentials) throws java.io.IOException parameter instance with index 1 method call "getAllTokens" returns with 
+[Kind: testKind, Service: testService, Ident: 74 65 73 74 49 64 65 6e 74 69 66 69 65 72]
 ```
 
 ### Summary of Parameters
@@ -320,16 +342,17 @@ All actions have the following set of arguments
 
 Here is the full list of actions and supported `params` 
 
-| Action               | Supported arguments                           |
-| -------------------- | --------------------------------------------- |
-| elapsed_time_in_nano | isDateLogged, log_threshold_nano              |
-| elapsed_time_in_ms   | isDateLogged, log_threshold_ms                |
-| stack_trace          | isDateLogged, log_threshold_ms, limit_count   |
-| trace_args           | isDateLogged, log_threshold_ms                |
-| trace_retval         | isDateLogged, log_threshold_ms                |
-| counter              | isDateLogged, count_frequency                 |
-| avg_timing           | isDateLogged, window_length                   |
-| trace_login_config   | isDateLogged, entry_name                      |
+| Action                  | Supported arguments                           |
+| ----------------------- | --------------------------------------------- |
+| elapsed_time_in_nano    | isDateLogged, log_threshold_nano              |
+| elapsed_time_in_ms      | isDateLogged, log_threshold_ms                |
+| stack_trace             | isDateLogged, log_threshold_ms, limit_count   |
+| trace_args              | isDateLogged, log_threshold_ms                |
+| trace_retval            | isDateLogged, log_threshold_ms                |
+| trace_param_call_retval | isDateLogged, param_index, method_to_call     |
+| counter                 | isDateLogged, count_frequency                 |
+| avg_timing              | isDateLogged, window_length                   |
+| trace_login_config      | isDateLogged, entry_name                      |
 
 
 ## Some complex examples how to specify a javaagent

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ KafkaClient {
 };
 ```
 
-# trace_param_call_retval action
+# trace_args_with_method_call action
 
 The action expects 2 parameters and calls a method on an argument instance:
 * `param_index` This is the index of the argument instance.
@@ -310,13 +310,13 @@ reflection so it can be used in situations where the number of calls is low.
 Example:
 
 ```
-trace_param_call_retval org.apache.hadoop.fs.FileSystem addDelegationTokens param_index:1,method_to_call:getAllTokens
+trace_args_with_method_call org.apache.hadoop.fs.FileSystem addDelegationTokens param_index:1,method_to_call:getAllTokens
 ```
 
 Example output:
 
 ```
-TraceAgent (trace_param_call_retval): public default org.apache.hadoop.security.token.Token[] org.apache.hadoop.security.token.DelegationTokenIssuer.addDelegationTokens(java.lang.String,org.apache.hadoop.security.Credentials) throws java.io.IOException parameter instance with index 1 method call "getAllTokens" returns with 
+TraceAgent (trace_args_with_method_call): public default org.apache.hadoop.security.token.Token[] org.apache.hadoop.security.token.DelegationTokenIssuer.addDelegationTokens(java.lang.String,org.apache.hadoop.security.Credentials) throws java.io.IOException parameter instance with index 1 method call "getAllTokens" returns with 
 [Kind: testKind, Service: testService, Ident: 74 65 73 74 49 64 65 6e 74 69 66 69 65 72]
 ```
 
@@ -342,17 +342,17 @@ All actions have the following set of arguments
 
 Here is the full list of actions and supported `params` 
 
-| Action                  | Supported arguments                           |
-| ----------------------- | --------------------------------------------- |
-| elapsed_time_in_nano    | isDateLogged, log_threshold_nano              |
-| elapsed_time_in_ms      | isDateLogged, log_threshold_ms                |
-| stack_trace             | isDateLogged, log_threshold_ms, limit_count   |
-| trace_args              | isDateLogged, log_threshold_ms                |
-| trace_retval            | isDateLogged, log_threshold_ms                |
-| trace_param_call_retval | isDateLogged, param_index, method_to_call     |
-| counter                 | isDateLogged, count_frequency                 |
-| avg_timing              | isDateLogged, window_length                   |
-| trace_login_config      | isDateLogged, entry_name                      |
+| Action                      | Supported arguments                           |
+| --------------------------- | --------------------------------------------- |
+| elapsed_time_in_nano        | isDateLogged, log_threshold_nano              |
+| elapsed_time_in_ms          | isDateLogged, log_threshold_ms                |
+| stack_trace                 | isDateLogged, log_threshold_ms, limit_count   |
+| trace_args                  | isDateLogged, log_threshold_ms                |
+| trace_retval                | isDateLogged, log_threshold_ms                |
+| trace_args_with_method_call | isDateLogged, param_index, method_to_call     |
+| counter                     | isDateLogged, count_frequency                 |
+| avg_timing                  | isDateLogged, window_length                   |
+| trace_login_config          | isDateLogged, entry_name                      |
 
 
 ## Some complex examples how to specify a javaagent

--- a/src/main/java/net/test/TraceAction.java
+++ b/src/main/java/net/test/TraceAction.java
@@ -7,8 +7,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 import static net.bytebuddy.matcher.ElementMatchers.*;
 
-import java.util.Map;
-
 class TraceAction {
 
   private final String actionId;
@@ -63,6 +61,8 @@ class TraceAction {
       interceptor = new AvgTimingInterceptorMs(actionArgs, defaultArguments);
     } else if (actionId.equals(TraceLoginConfigInterceptor.NAME)) {
       interceptor = new TraceLoginConfigInterceptor(actionArgs, defaultArguments);
+    } else if (actionId.equals(TraceParamCallRetValueInterceptor.NAME)) {
+      interceptor = new TraceParamCallRetValueInterceptor(actionArgs, defaultArguments);
     } else {
       System.err.println("TraceAgent detected an invalid action: " + actionId);
       interceptor = null;

--- a/src/main/java/net/test/TraceAction.java
+++ b/src/main/java/net/test/TraceAction.java
@@ -61,8 +61,8 @@ class TraceAction {
       interceptor = new AvgTimingInterceptorMs(actionArgs, defaultArguments);
     } else if (actionId.equals(TraceLoginConfigInterceptor.NAME)) {
       interceptor = new TraceLoginConfigInterceptor(actionArgs, defaultArguments);
-    } else if (actionId.equals(TraceParamCallRetValueInterceptor.NAME)) {
-      interceptor = new TraceParamCallRetValueInterceptor(actionArgs, defaultArguments);
+    } else if (actionId.equals(TraceArgsWithMethodCallInterceptor.NAME)) {
+      interceptor = new TraceArgsWithMethodCallInterceptor(actionArgs, defaultArguments);
     } else {
       System.err.println("TraceAgent detected an invalid action: " + actionId);
       interceptor = null;

--- a/src/main/java/net/test/interceptor/TraceArgsWithMethodCallInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceArgsWithMethodCallInterceptor.java
@@ -14,9 +14,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-public class TraceParamCallRetValueInterceptor {
+public class TraceArgsWithMethodCallInterceptor {
 
-  public static String NAME = "trace_param_call_retval";
+  public static String NAME = "trace_args_with_method_call";
 
   private static String PARAM_INDEX = "param_index";
 
@@ -29,13 +29,13 @@ public class TraceParamCallRetValueInterceptor {
 
   private final int paramIndex;
 
-  private final String methodToCall;
+  private final String methodToCallName;
 
-  public TraceParamCallRetValueInterceptor(String actionArgs, DefaultArguments defaults) {
+  public TraceArgsWithMethodCallInterceptor(String actionArgs, DefaultArguments defaults) {
     ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
     this.commonActionArgs = new CommonActionArgs(parsed, defaults);
     this.paramIndex = parsed.parseInt(PARAM_INDEX, 0);
-    this.methodToCall = parsed.get(METHOD_TO_CALL);
+    this.methodToCallName = parsed.get(METHOD_TO_CALL);
   }
 
   @RuntimeType
@@ -45,10 +45,10 @@ public class TraceParamCallRetValueInterceptor {
     String retVal = "";
     if (allArguments.length > paramIndex) {
       try {
-        Method getAllTokens = allArguments[paramIndex].getClass().getMethod(methodToCall);
-        retVal = getAllTokens.invoke(allArguments[paramIndex]).toString();
+        Method methodToCall = allArguments[paramIndex].getClass().getMethod(methodToCallName);
+        retVal = methodToCall.invoke(allArguments[paramIndex]).toString();
       } catch (NoSuchMethodException e) {
-        retVal = "No such method found: " + methodToCall;
+        retVal = "No such method found: " + methodToCallName;
       }
     } else {
       retVal =
@@ -59,12 +59,12 @@ public class TraceParamCallRetValueInterceptor {
     }
     System.out.println(
         commonActionArgs.addPrefix(
-            "TraceAgent (trace_param_call_retval): "
+            "TraceAgent (trace_args_with_method_call): "
                 + method
                 + " parameter instance with index "
                 + paramIndex
                 + " method call \""
-                + methodToCall
+                + methodToCallName
                 + "\" returns with \n"
                 + retVal));
     return callable.call();

--- a/src/main/java/net/test/interceptor/TraceParamCallRetValueInterceptor.java
+++ b/src/main/java/net/test/interceptor/TraceParamCallRetValueInterceptor.java
@@ -1,0 +1,72 @@
+package net.test.interceptor;
+
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.test.ArgUtils;
+import net.test.ArgumentsCollection;
+import net.test.CommonActionArgs;
+import net.test.DefaultArguments;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class TraceParamCallRetValueInterceptor {
+
+  public static String NAME = "trace_param_call_retval";
+
+  private static String PARAM_INDEX = "param_index";
+
+  private static String METHOD_TO_CALL = "method_to_call";
+
+  private static List<String> KNOWN_ARGS =
+      Arrays.asList(CommonActionArgs.IS_DATE_LOGGED, PARAM_INDEX, METHOD_TO_CALL);
+
+  private CommonActionArgs commonActionArgs;
+
+  private final int paramIndex;
+
+  private final String methodToCall;
+
+  public TraceParamCallRetValueInterceptor(String actionArgs, DefaultArguments defaults) {
+    ArgumentsCollection parsed = ArgUtils.parseOptionalArgs(KNOWN_ARGS, actionArgs);
+    this.commonActionArgs = new CommonActionArgs(parsed, defaults);
+    this.paramIndex = parsed.parseInt(PARAM_INDEX, 0);
+    this.methodToCall = parsed.get(METHOD_TO_CALL);
+  }
+
+  @RuntimeType
+  public Object intercept(
+      @Origin Method method, @AllArguments Object[] allArguments, @SuperCall Callable<?> callable)
+      throws Exception {
+    String retVal = "";
+    if (allArguments.length > paramIndex) {
+      try {
+        Method getAllTokens = allArguments[paramIndex].getClass().getMethod(methodToCall);
+        retVal = getAllTokens.invoke(allArguments[paramIndex]).toString();
+      } catch (NoSuchMethodException e) {
+        retVal = "No such method found: " + methodToCall;
+      }
+    } else {
+      retVal =
+          "Parameter tried to be get with index "
+              + paramIndex
+              + " but max index is "
+              + (allArguments.length - 1);
+    }
+    System.out.println(
+        commonActionArgs.addPrefix(
+            "TraceAgent (trace_param_call_retval): "
+                + method
+                + " parameter instance with index "
+                + paramIndex
+                + " method call \""
+                + methodToCall
+                + "\" returns with \n"
+                + retVal));
+    return callable.call();
+  }
+}


### PR DESCRIPTION
It's tested in the following way.

Application to trace: https://github.com/gaborgsomogyi/hadoop-token-trace

```
[gaborsomogyi:~/trace-agent] hadoop_token* 4s ± cat src/main/resources/actions.txt 
trace_args_with_method_call org.apache.hadoop.fs.FileSystem addDelegationTokens param_index:1,method_to_call:getAllTokens
...
java -javaagent:/Users/gaborsomogyi/trace-agent/target/trace-agent-1.0-SNAPSHOT.jar -jar target/hadoop-token-trace-1.0-SNAPSHOT-jar
...
TraceAgent (trace_args_with_method_call): public default org.apache.hadoop.security.token.Token[] org.apache.hadoop.security.token.DelegationTokenIssuer.addDelegationTokens(java.lang.String,org.apache.hadoop.security.Credentials) throws java.io.IOException parameter instance with index 1 method call "getAllTokens" returns with 
[Kind: testKind, Service: testService, Ident: 74 65 73 74 49 64 65 6e 74 69 66 69 65 72]
...
```
