### PR TITLE
Attach the Agent to a running process

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,19 +255,6 @@ In this case all the rules are used from both the internal and external action f
 In distributed environment when external action file is used you should take care on each node the action file is really can be accessed using the path.
 Otherwise the error is logged but the application continues: "TraceAgent does not find the external action file: <file>".
 
-#### Redirect output to  log4j logger.
-
-By adding this argument we can instruct the agent to add the file to log4j logger instead of stdout.
-
-```
-java -javaagent:target/trace-agent-1.0-SNAPSHOT.jar="use_log4j:true" -jar ../testartifact/target/testartifact-1.0-SNAPSHOT.jar
-
-21/03/15 16:57:47 INFO TraceAgent: TraceAgent (trace_args_with_method_call): public java.lang.Object org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(org.apache.spark.sql.SparkSession,org.apache.spark.sql.execution.QueryExecution,scala.Function0) parameter instance with index 1 method call "getAllTokens" returns with
-21/03/15 16:57:47 INFO TraceAgent: TraceAgent (trace_args): `public java.lang.String org.apache.spark.sql.execution.SQLExecution$.EXECUTION_ID_KEY() called with []
-```
-
-The default is to write to the stdout.
-
 
 # The counter action
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ methodWithArgs
 TraceAgent (trace_retval): `public int net.test.TestClass2nd.methodWithArgs(java.lang.String,int) returns with 12
 ```
 
+## Attaching Agent to running java process (hotswap)
+
+The agent can be attached to already running java process. 
+
+To start trace on a running process one can use:
+
+```
+$ java -cp <JAVA HOME>/lib/tools.jar:target/trace-agent-1.0-SNAPSHOT.jar net.test.AgentLoader  target/trace-agent-1.0-SNAPSHOT.jar <PID of process>
+
+The above command attaches to the running java process and installs the actions. The instrumentaion messages will start showing in the processes logs/stdout as per the configuration.
+
+For example when attaching to a Spark executor using its pid:
+...
+21/03/17 13:30:52 INFO yarn.Client: Application report for application_1614936955492_0466 (state: ACCEPTED)
+TraceAgent is initializing
+TraceAgent tries to install actions: [{actionId='trace_args', classMatcher='REGEXP(org\.apache\.spark\.sql\.execution\.SparkStratgies.*)'}, ...]
+TraceAgent installed actions successfully
+...
+21/03/17 14:18:33 INFO yarn.Client: Application report for application_1614936955492_0470 (state: RUNNING)
+21/03/17 14:18:34 INFO util.Utils: Using initial executors = 0, max of spark.dynamicAllocation.initialExecutors, spark.dynamicAllocation.minExecutors and spark.executor.instances
+TraceAgent (timing): `public final void org.apache.spark.SparkContext$$anonfun$23.apply(org.apache.spark.ExecutorAllocationManager)` took 22 ms
+TraceAgent (timing): `public final void org.apache.spark.SparkContext$$anonfun$24.apply(org.apache.spark.ContextCleaner)` took 2 ms
+....
+
+```
 
 ## The config format
 
@@ -229,6 +254,20 @@ In this case all the rules are used from both the internal and external action f
 
 In distributed environment when external action file is used you should take care on each node the action file is really can be accessed using the path.
 Otherwise the error is logged but the application continues: "TraceAgent does not find the external action file: <file>".
+
+#### Redirect output to  log4j logger.
+
+By adding this argument we can instruct the agent to add the file to log4j logger instead of stdout.
+
+```
+java -javaagent:target/trace-agent-1.0-SNAPSHOT.jar="use_log4j:true" -jar ../testartifact/target/testartifact-1.0-SNAPSHOT.jar
+
+21/03/15 16:57:47 INFO TraceAgent: TraceAgent (trace_args_with_method_call): public java.lang.Object org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(org.apache.spark.sql.SparkSession,org.apache.spark.sql.execution.QueryExecution,scala.Function0) parameter instance with index 1 method call "getAllTokens" returns with
+21/03/15 16:57:47 INFO TraceAgent: TraceAgent (trace_args): `public java.lang.String org.apache.spark.sql.execution.SQLExecution$.EXECUTION_ID_KEY() called with []
+```
+
+The default is to write to the stdout.
+
 
 # The counter action
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <premain>net.test.TraceAgent</premain>
+    <java.version>1.8</java.version>
+    <sun.tools.version>1.8.0</sun.tools.version>
   </properties>
 
   <dependencies>
@@ -28,6 +30,13 @@
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
       <version>1.10.10</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+      <version>${sun.tools.version}</version>
+      <scope>system</scope>
+      <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
   </dependencies>
 

--- a/src/main/java/net/test/AgentLoader.java
+++ b/src/main/java/net/test/AgentLoader.java
@@ -1,0 +1,26 @@
+package net.test;
+
+import com.sun.tools.attach.VirtualMachine;
+
+import java.io.File;
+import java.util.Optional;
+
+/** Agent Loader to attach to a PID. */
+public class AgentLoader {
+
+  public static void main(String[] args) {
+    File agentFile = new File(args[0]);
+
+    System.out.println(agentFile.getAbsolutePath());
+    try {
+      String pid = args[1];
+      System.out.println("Attaching to target JVM with PID: " + pid);
+      VirtualMachine jvm = VirtualMachine.attach(pid);
+      jvm.loadAgent(agentFile.getAbsolutePath());
+      jvm.detach();
+      System.out.println("Succefully attached to target JVM and loaded Java agent");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/net/test/TraceAgent.java
+++ b/src/main/java/net/test/TraceAgent.java
@@ -79,6 +79,7 @@ public class TraceAgent {
       final Object interceptor = action.getActionInterceptor(traceAgentArgs);
       if (interceptor != null) {
         new AgentBuilder.Default()
+            .with(new AgentBuilder.InitializationStrategy.SelfInjection.Eager())
             .type(action.getClassMatcher())
             .transform(
                 (builder, type, classLoader, module) ->
@@ -116,5 +117,9 @@ public class TraceAgent {
     TraceAgentArgs traceAgentArgs = new TraceAgentArgs(arguments);
     TraceAgent traceAgent = new TraceAgent(traceAgentArgs, instrumentation);
     traceAgent.install();
+  }
+
+  public static void agentmain(String arguments, Instrumentation instrumentation) {
+    premain(arguments, instrumentation);
   }
 }


### PR DESCRIPTION
With this change we will be able to attach the agent to a running java process and install all the action and see the messages without have to restart the process. 